### PR TITLE
fix: hide article like header when disabled

### DIFF
--- a/docs/widget/src/core/CWDComments.js
+++ b/docs/widget/src/core/CWDComments.js
@@ -395,8 +395,9 @@ export class CWDComments {
 			header = document.createElement('div');
 			header.className = 'cwd-comments-header';
 			const showArticleLike = this.config.enableArticleLike !== false;
+			header.style.display = showArticleLike ? '' : 'none';
 			header.innerHTML = `
-				<div class="cwd-like" ${showArticleLike ? '' : 'style="display: none;"'}>
+				<div class="cwd-like">
           <button type="button" class="cwd-like-button" data-liked="false">
             <span class="cwd-like-icon-wrapper">
               <svg class="cwd-like-icon" viewBox="0 0 24 24" aria-hidden="true">


### PR DESCRIPTION
## Summary

- hide the entire comments header when article likes are disabled
- remove the redundant inline visibility style from the child like container

## Problem

When `enableArticleLike` is `false`, the widget hides `.cwd-like` but still renders `.cwd-comments-header`. The header keeps its `16px 0` padding, leaving an empty vertical gap above the comment form.

## Impact

The empty gap is removed when article likes are disabled. The enabled article-like UI is unchanged.

## Validation

- `npm run build` in `docs/widget`
