### PR TITLE
fix: keep Markdown line breaks consistent with preview

### DIFF
--- a/cwd-api/src/api/admin/updateComment.ts
+++ b/cwd-api/src/api/admin/updateComment.ts
@@ -1,8 +1,8 @@
 import { Context } from 'hono';
 import { Bindings } from '../../bindings';
 import { checkContent } from '../public/postComment';
-import { marked } from 'marked';
 import xss from 'xss';
+import { parseMarkdown } from '../../utils/markdown';
 
 export const updateComment = async (c: Context<{ Bindings: Bindings }>) => {
   let body: any;
@@ -112,7 +112,7 @@ export const updateComment = async (c: Context<{ Bindings: Bindings }>) => {
     return c.json({ message: '评论内容不能为空' }, 400);
   }
 
-  const html = await marked.parse(cleanedContent, { async: true });
+  const html = await parseMarkdown(cleanedContent);
   const contentHtml = xss(html, {
     whiteList: {
       ...xss.whiteList,
@@ -138,4 +138,3 @@ export const updateComment = async (c: Context<{ Bindings: Bindings }>) => {
     message: `Comment updated, id: ${id}.`
   });
 };
-

--- a/cwd-api/src/api/public/postComment.ts
+++ b/cwd-api/src/api/public/postComment.ts
@@ -1,8 +1,8 @@
 import { Context } from 'hono';
 import { UAParser } from 'ua-parser-js';
-import { marked } from 'marked';
 import xss from 'xss';
 import { Bindings } from '../../bindings';
+import { parseMarkdown } from '../../utils/markdown';
 import {
   sendCommentNotification,
   sendCommentReplyNotification,
@@ -134,7 +134,7 @@ export const postComment = async (c: Context<{ Bindings: Bindings }>) => {
   const name = checkContent(rawName);
 
   // Markdown 渲染与 XSS 过滤
-  const html = await marked.parse(cleanedContent, { async: true });
+  const html = await parseMarkdown(cleanedContent);
   const contentHtml = xss(html, {
     whiteList: {
       ...xss.whiteList,

--- a/cwd-api/src/utils/markdown.spec.ts
+++ b/cwd-api/src/utils/markdown.spec.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { parseMarkdown } from './markdown';
+
+describe('parseMarkdown', () => {
+	it('renders a single newline as a line break', async () => {
+		await expect(parseMarkdown('first line\nsecond line')).resolves.toBe('<p>first line<br>second line</p>\n');
+	});
+});

--- a/cwd-api/src/utils/markdown.ts
+++ b/cwd-api/src/utils/markdown.ts
@@ -1,0 +1,11 @@
+import { marked } from 'marked';
+
+/**
+ * Parse comment Markdown with the same line-break behavior as the widget preview.
+ */
+export const parseMarkdown = async (content: string): Promise<string> =>
+	marked.parse(content, {
+		async: true,
+		gfm: true,
+		breaks: true,
+	});


### PR DESCRIPTION
## Summary

- centralize the backend `marked` options used for comment creation and admin edits
- enable `gfm: true` and `breaks: true` to match the widget preview
- add a regression test for single-newline rendering

## Root cause

The widget preview enables `breaks: true`, but the backend previously called `marked.parse()` without that option. A single newline therefore appeared as a line break in preview but was collapsed to whitespace after the comment was saved or edited.

## Impact

New and edited comments now preserve single newlines consistently with the preview. The API schema and XSS sanitization behavior are unchanged. This patch does not migrate existing comment records.

## Validation

- `./node_modules/.bin/vitest --run` (4 files, 11 tests passed)
- `git diff --check`

`tsc --noEmit` still reports the repository's existing errors in `telegramSettings.ts` and the existing `xss.whiteList` typings in the two comment handlers; this patch introduces no additional type errors.
