### PR TITLE
fix: align comment post URL schema and imports

### DIFF
--- a/cwd-api/schemas/comment.sql
+++ b/cwd-api/schemas/comment.sql
@@ -3,6 +3,7 @@ CREATE TABLE IF NOT EXISTS Comment (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     created INTEGER NOT NULL,
     post_slug TEXT NOT NULL,
+    post_url TEXT,
     name TEXT NOT NULL,
     email TEXT NOT NULL,
     url TEXT,

--- a/cwd-api/src/api/admin/commentPostUrlImport.spec.ts
+++ b/cwd-api/src/api/admin/commentPostUrlImport.spec.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest';
+import { importBackup } from './importBackup';
+import { importComments } from './importComments';
+
+function createMockContext(body: unknown) {
+	const statements: Array<{ sql: string; args: unknown[] }> = [];
+	const db = {
+		prepare(sql: string) {
+			return {
+				bind(...args: unknown[]) {
+					const statement = { sql, args };
+					statements.push(statement);
+					return statement;
+				},
+				async run() {
+					return { success: true };
+				},
+			};
+		},
+		batch: vi.fn().mockResolvedValue([]),
+	};
+	const context = {
+		req: { json: vi.fn().mockResolvedValue(body) },
+		env: { CWD_DB: db },
+		json: vi.fn((payload, status) => ({ payload, status })),
+	} as any;
+
+	return { context, statements };
+}
+
+function findCommentInsert(statements: Array<{ sql: string; args: unknown[] }>) {
+	return statements.find((statement) => statement.sql.startsWith('INSERT OR REPLACE INTO Comment'));
+}
+
+const comment = {
+	id: 42,
+	created: 1_700_000_000_000,
+	post_slug: '/post/',
+	post_url: 'https://example.com/post/',
+	name: 'Reader',
+	email: 'reader@example.com',
+	content_text: 'Hello',
+	content_html: '<p>Hello</p>',
+};
+
+describe('comment post_url imports', () => {
+	it.each([
+		['comment import', importComments, [comment]],
+		['backup import', importBackup, { comments: [comment] }],
+	])('preserves post_url through %s', async (_name, handler, body) => {
+		const { context, statements } = createMockContext(body);
+
+		await handler(context);
+
+		const insert = findCommentInsert(statements);
+		expect(insert?.sql).toContain('post_url');
+		expect(insert?.args[3]).toBe(comment.post_url);
+	});
+
+	it('keeps old backups without post_url compatible', async () => {
+		const { post_url: _postUrl, ...legacyComment } = comment;
+		const { context, statements } = createMockContext({ comments: [legacyComment] });
+
+		await importBackup(context);
+
+		expect(findCommentInsert(statements)?.args[3]).toBeNull();
+	});
+});

--- a/cwd-api/src/api/admin/importBackup.ts
+++ b/cwd-api/src/api/admin/importBackup.ts
@@ -13,6 +13,7 @@ const saveComments = async (env: Bindings, comments: any[]) => {
             id,
             created,
             post_slug,
+            post_url,
             name,
             email,
             url,
@@ -30,13 +31,14 @@ const saveComments = async (env: Bindings, comments: any[]) => {
 			} = comment;
 
             const fields = [
-                'created', 'post_slug', 'name', 'email', 'url',
+                'created', 'post_slug', 'post_url', 'name', 'email', 'url',
                 'ip_address', 'device', 'os', 'browser', 'ua',
                 'content_text', 'content_html', 'parent_id', 'status', 'likes', 'site_id'
             ];
             const values = [
                 created || Date.now(),
                 post_slug || "",
+                post_url || null,
                 name || "Anonymous",
                 email || "",
                 url || null,

--- a/cwd-api/src/api/admin/importComments.ts
+++ b/cwd-api/src/api/admin/importComments.ts
@@ -145,6 +145,7 @@ export const importComments = async (c: Context<{ Bindings: Bindings }>) => {
 				id,
 				created,
 				post_slug,
+				post_url,
 				name,
 				email,
 				url,
@@ -162,13 +163,14 @@ export const importComments = async (c: Context<{ Bindings: Bindings }>) => {
 			} = comment;
 
             const fields = [
-                'created', 'post_slug', 'name', 'email', 'url',
+                'created', 'post_slug', 'post_url', 'name', 'email', 'url',
                 'ip_address', 'device', 'os', 'browser', 'ua',
                 'content_text', 'content_html', 'parent_id', 'status', 'likes', 'site_id'
             ];
             const values = [
                 created || Date.now(),
                 post_slug || "",
+                post_url || null,
                 name || "Anonymous",
                 email || "",
                 url || null,

--- a/cwd-api/src/utils/dbMigration.spec.ts
+++ b/cwd-api/src/utils/dbMigration.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ensureSchema } from './dbMigration';
+
+function createMockEnv(commentColumns: Array<{ name: string }>) {
+	const executedSql: string[] = [];
+	const prepare = vi.fn((sql: string) => ({
+		async all() {
+			if (sql === 'PRAGMA table_info(Comment)') {
+				return { results: commentColumns };
+			}
+			return { results: [{ name: 'site_id' }] };
+		},
+		async run() {
+			executedSql.push(sql);
+			return { success: true };
+		},
+	}));
+
+	return {
+		env: { CWD_DB: { prepare } } as any,
+		executedSql,
+	};
+}
+
+describe('ensureSchema Comment.post_url migration', () => {
+	it('adds post_url to an existing Comment table when it is missing', async () => {
+		const { env, executedSql } = createMockEnv([{ name: 'id' }, { name: 'post_slug' }]);
+
+		await ensureSchema(env);
+
+		expect(executedSql).toContain('ALTER TABLE Comment ADD COLUMN post_url TEXT');
+	});
+
+	it('does not alter Comment when post_url already exists', async () => {
+		const { env, executedSql } = createMockEnv([{ name: 'id' }, { name: 'post_url' }]);
+
+		await ensureSchema(env);
+
+		expect(executedSql).not.toContain('ALTER TABLE Comment ADD COLUMN post_url TEXT');
+	});
+});

--- a/cwd-api/src/utils/dbMigration.ts
+++ b/cwd-api/src/utils/dbMigration.ts
@@ -117,7 +117,18 @@ export async function ensureSchema(env: Bindings) {
 			).run();
 		}
 
-		// 4. Create Indexes
+		// 4. Check and migrate Comment
+		const commentInfo = await env.CWD_DB.prepare('PRAGMA table_info(Comment)').all();
+		const commentColumns = (commentInfo.results || []) as any[];
+		const hasCommentPostUrl = commentColumns.some((col) => col.name === 'post_url');
+
+		if (!hasCommentPostUrl && commentColumns.length > 0) {
+			console.log('Migrating Comment table...');
+			await env.CWD_DB.prepare('ALTER TABLE Comment ADD COLUMN post_url TEXT').run();
+			console.log('Migrated Comment table successfully.');
+		}
+
+		// 5. Create Indexes
 		await env.CWD_DB.prepare('CREATE INDEX IF NOT EXISTS idx_page_stats_site_id ON page_stats(site_id)').run();
 		await env.CWD_DB.prepare('CREATE INDEX IF NOT EXISTS idx_page_visit_daily_site_id ON page_visit_daily(site_id)').run();
 		await env.CWD_DB.prepare('CREATE INDEX IF NOT EXISTS idx_likes_site_id ON Likes(site_id)').run();


### PR DESCRIPTION
## Summary

- add the nullable `post_url` column to the canonical `Comment` schema
- make the runtime schema check add the column to existing databases when needed
- preserve `post_url` through comment and full-backup imports
- keep older backups without `post_url` compatible by importing `NULL`

## Root cause

The comment API already reads, writes, and edits `Comment.post_url`, and the deployment migration can add it, but the canonical schema and runtime schema check did not guarantee that the column existed. Import paths also dropped the value during backup round trips.

## Compatibility

The migration is additive and idempotent. Existing rows keep `NULL`, databases already containing the column are unchanged, and older backup payloads remain supported.

## Validation

- `./node_modules/.bin/vitest run` (5 files, 15 tests passed)
- `git diff --check`

`tsc --noEmit` still reports the six pre-existing errors covered by #26; this change introduces no additional TypeScript errors.